### PR TITLE
Default Sort for Sortable List View

### DIFF
--- a/Main/SEToolbox/SEToolbox/Controls/SortableListView.cs
+++ b/Main/SEToolbox/SEToolbox/Controls/SortableListView.cs
@@ -7,6 +7,7 @@
     using System.Windows.Controls;
     using System.Windows.Data;
     using System.Windows.Input;
+    using System.Windows.Media;
 
     using SEToolbox.Support;
 
@@ -26,6 +27,13 @@
 
         #endregion
 
+        public static readonly DependencyProperty DefaultSortColumnProperty = DependencyProperty.Register("DefaultSortColumn", typeof(string), typeof(SortableListView));
+        public string DefaultSortColumn
+        {
+            get { return (string)GetValue(DefaultSortColumnProperty); }
+            set { SetValue(DefaultSortColumnProperty, value); }
+        }
+
         #region ColumnHeaderArrowDownTemplate
 
         public static readonly DependencyProperty ColumnHeaderArrowDownTemplateProperty = DependencyProperty.Register("ColumnHeaderArrowDownTemplate", typeof(DataTemplate), typeof(SortableListView));
@@ -44,6 +52,16 @@
             // add the event handler to the GridViewColumnHeader. This strongly ties this ListView to a GridView.
             AddHandler(GridViewColumnHeader.ClickEvent, new RoutedEventHandler(GridViewColumnHeaderClickedHandler));
             AddHandler(ListView.MouseDoubleClickEvent, new RoutedEventHandler(MouseDoubleClickedHandler));
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            base.OnRender(drawingContext);
+
+            if (!string.IsNullOrWhiteSpace(this.DefaultSortColumn))
+            {
+                Sort(this, new List<string>() { this.DefaultSortColumn }, ListSortDirection.Ascending);
+            }
         }
 
         private void GridViewColumnHeaderClickedHandler(object sender, RoutedEventArgs e)

--- a/Main/SEToolbox/SEToolbox/Views/ControlCubeGrid.xaml
+++ b/Main/SEToolbox/SEToolbox/Views/ControlCubeGrid.xaml
@@ -357,7 +357,7 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*" MinHeight="100"/>
                             </Grid.RowDefinitions>
-                            <controls:SortableListView Grid.Row="0" ItemsSource="{Binding CubeList, Mode=OneWay}"
+                            <controls:SortableListView Grid.Row="0" ItemsSource="{Binding CubeList, Mode=OneWay}" DefaultSortColumn="FriendlyName"
                             ColumnHeaderArrowUpTemplate="{StaticResource HeaderTemplateArrowUp}" ColumnHeaderArrowDownTemplate="{StaticResource HeaderTemplateArrowDown}" SelectedValue="{Binding SelectedCubeItem}">
                                 <ListView.View>
                                     <GridView>

--- a/Main/SEToolbox/SEToolbox/Views/WindowExplorer.xaml
+++ b/Main/SEToolbox/SEToolbox/Views/WindowExplorer.xaml
@@ -341,7 +341,7 @@
                 <Grid Grid.Column="0">
                     <TabControl>
                         <TabItem Header="Craft/Objects">
-                            <controls:SortableListView DisplayMemberPath="ClassType" SelectionMode="Extended" ItemsSource="{Binding Structures}" SelectedValue="{Binding SelectedStructure, Mode=TwoWay}"
+                            <controls:SortableListView DisplayMemberPath="ClassType" SelectionMode="Extended" DefaultSortColumn="DisplayName"  ItemsSource="{Binding Structures}" SelectedValue="{Binding SelectedStructure, Mode=TwoWay}"
                             ColumnHeaderArrowUpTemplate="{StaticResource HeaderTemplateArrowUp}" ColumnHeaderArrowDownTemplate="{StaticResource HeaderTemplateArrowDown}">
                                 <ListView.Resources>
                                     <commands:Behaviors x:Key="dragBehavior" x:Shared="False">


### PR DESCRIPTION
This is a minor change to add a property to the SortableListView that allows setting a default sort to grids and then adding the default sort to the WindowExplorer and CubeListView.

When I'm using these, I find that I almost always have to sort the list before I can actually use the list. :)

Please let me know if you have any questions.

Robert