### PR TITLE
Make default visibility of busy indicator hidden

### DIFF
--- a/Main/SEToolbox/SEToolbox/Views/WindowExplorer.xaml
+++ b/Main/SEToolbox/SEToolbox/Views/WindowExplorer.xaml
@@ -498,6 +498,6 @@
                 </Grid>
             </Grid>
         </DockPanel>
-        <controls:BusyIndicator Visibility="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}" />
+        <controls:BusyIndicator Visibility="{Binding IsBusy, FallbackValue=Hidden, Converter={StaticResource BooleanToVisibilityConverter}}" />
     </Grid>
 </Window>


### PR DESCRIPTION
Makes design-time editor easier to use